### PR TITLE
✨ Feat: 컬렉션뷰 헤더 및 푸터 구현

### DIFF
--- a/Kiosk/Kiosk/Presentation/Cart/Subview/SectionHeaderView.swift
+++ b/Kiosk/Kiosk/Presentation/Cart/Subview/SectionHeaderView.swift
@@ -1,9 +1,7 @@
 import SnapKit
 import UIKit
 
-final class SectionHeaderView: UICollectionReusableView {
-    static let identifier = Common.Identifier.cartSection
-
+final class SectionHeaderView: UICollectionReusableView, ReuseIdentifying {
     private let titleLabel = UILabel()
 
     override init(frame: CGRect) {
@@ -23,7 +21,8 @@ final class SectionHeaderView: UICollectionReusableView {
         addSubview(titleLabel)
 
         titleLabel.snp.makeConstraints {
-            $0.edges.equalToSuperview().inset(16)
+            $0.top.trailing.equalToSuperview()
+            $0.leading.bottom.equalToSuperview().inset(Common.Config.defaultSpacing)
         }
     }
 

--- a/Kiosk/Kiosk/Presentation/Cart/Subview/SectionHeaderView.swift
+++ b/Kiosk/Kiosk/Presentation/Cart/Subview/SectionHeaderView.swift
@@ -21,8 +21,7 @@ final class SectionHeaderView: UICollectionReusableView, ReuseIdentifying {
         addSubview(titleLabel)
 
         titleLabel.snp.makeConstraints {
-            $0.top.trailing.equalToSuperview()
-            $0.leading.bottom.equalToSuperview().inset(Common.Config.defaultSpacing)
+            $0.edges.equalToSuperview()
         }
     }
 

--- a/Kiosk/Kiosk/Presentation/CollectionView/CollectionViewConstant.swift
+++ b/Kiosk/Kiosk/Presentation/CollectionView/CollectionViewConstant.swift
@@ -13,8 +13,13 @@ enum CollectionViewConstant {
         static let estimatedHeight: CGFloat = 100
         static let movieHeight: CGFloat = 450
     }
-    
+
     enum Spacing {
         static let interGroup: CGFloat = 8
+    }
+
+    enum Inset {
+        static let sectionTop: CGFloat = 15
+        static let sectionBottom: CGFloat = 25
     }
 }

--- a/Kiosk/Kiosk/Presentation/CollectionView/CollectionViewConstant.swift
+++ b/Kiosk/Kiosk/Presentation/CollectionView/CollectionViewConstant.swift
@@ -12,6 +12,7 @@ enum CollectionViewConstant {
         static let movieGroupWidth: CGFloat = 0.92
         static let estimatedHeight: CGFloat = 100
         static let movieHeight: CGFloat = 450
+        static let supplementaryHeight: CGFloat = 30
     }
 
     enum Spacing {

--- a/Kiosk/Kiosk/Presentation/CollectionView/MovieCollectionView.swift
+++ b/Kiosk/Kiosk/Presentation/CollectionView/MovieCollectionView.swift
@@ -37,6 +37,11 @@ final class MovieCollectionView: UIView {
             forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
             withReuseIdentifier: SectionHeaderView.reuseIdentifier
         )
+        $0.register(
+            PageControlFooterView.self,
+            forSupplementaryViewOfKind: UICollectionView.elementKindSectionFooter,
+            withReuseIdentifier: PageControlFooterView.reuseIdentifier
+        )
     }
 
     // MARK: - Init
@@ -75,7 +80,8 @@ extension MovieCollectionView {
             let section = sections[sectionIndex]
             switch section {
             case .movieInfo:
-                return createMovieInfoSection()
+                let footerItem = createFooterItem()
+                return createMovieInfoSection(supplementaryItems: [footerItem])
             case .cart:
                 let headerItem = createHeaderItem()
                 return createCartSection(supplementaryItems: [headerItem])
@@ -89,7 +95,7 @@ extension MovieCollectionView {
     private func createHeaderItem() -> NSCollectionLayoutBoundarySupplementaryItem {
         let headerSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(Dimension.defaultWidth),
-            heightDimension: .estimated(Dimension.estimatedHeight)
+            heightDimension: .absolute(Dimension.supplementaryHeight + Common.Config.defaultSpacing * 2)
         )
 
         let headerItem = NSCollectionLayoutBoundarySupplementaryItem(
@@ -97,11 +103,34 @@ extension MovieCollectionView {
             elementKind: UICollectionView.elementKindSectionHeader,
             alignment: .top
         )
+        headerItem.contentInsets = .init(
+            top: Common.Config.defaultSpacing,
+            leading: Common.Config.defaultSpacing,
+            bottom: Common.Config.defaultSpacing,
+            trailing: .zero
+        )
 
         return headerItem
     }
 
-    private func createMovieInfoSection() -> NSCollectionLayoutSection {
+    private func createFooterItem() -> NSCollectionLayoutBoundarySupplementaryItem {
+        let footerSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(Dimension.defaultWidth),
+            heightDimension: .absolute(Dimension.supplementaryHeight * 3)
+        )
+
+        let footerItem = NSCollectionLayoutBoundarySupplementaryItem(
+            layoutSize: footerSize,
+            elementKind: UICollectionView.elementKindSectionFooter,
+            alignment: .bottom
+        )
+
+        return footerItem
+    }
+
+    private func createMovieInfoSection(supplementaryItems: [NSCollectionLayoutBoundarySupplementaryItem])
+        -> NSCollectionLayoutSection
+    {
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(Dimension.defaultWidth),
             heightDimension: .absolute(Dimension.movieHeight)
@@ -116,13 +145,14 @@ extension MovieCollectionView {
 
         let section = NSCollectionLayoutSection(group: group)
         section.contentInsets = .init(
-            top: Inset.sectionTop,
+            top: .zero,
             leading: Common.Config.defaultSpacing,
-            bottom: Inset.sectionBottom,
+            bottom: .zero,
             trailing: Common.Config.defaultSpacing
         )
         section.interGroupSpacing = Spacing.interGroup
         section.orthogonalScrollingBehavior = .groupPagingCentered
+        section.boundarySupplementaryItems = supplementaryItems
 
         return section
     }

--- a/Kiosk/Kiosk/Presentation/CollectionView/MovieCollectionView.swift
+++ b/Kiosk/Kiosk/Presentation/CollectionView/MovieCollectionView.swift
@@ -15,6 +15,7 @@ final class MovieCollectionView: UIView {
     private typealias MovieCell = MovieInfoCell
     private typealias Dimension = CollectionViewConstant.Dimension
     private typealias Spacing = CollectionViewConstant.Spacing
+    private typealias Inset = CollectionViewConstant.Inset
 
     // MARK: - Properties
 
@@ -30,6 +31,12 @@ final class MovieCollectionView: UIView {
         $0.register(MovieCell.self, forCellWithReuseIdentifier: MovieCell.reuseIdentifier)
         $0.register(CartCell.self, forCellWithReuseIdentifier: CartCell.reuseIdentifier)
         $0.register(PaymentCell.self, forCellWithReuseIdentifier: PaymentCell.reuseIdentifier)
+
+        $0.register(
+            SectionHeaderView.self,
+            forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
+            withReuseIdentifier: SectionHeaderView.reuseIdentifier
+        )
     }
 
     // MARK: - Init
@@ -70,12 +77,28 @@ extension MovieCollectionView {
             case .movieInfo:
                 return createMovieInfoSection()
             case .cart:
-                return createCartSection()
+                let headerItem = createHeaderItem()
+                return createCartSection(supplementaryItems: [headerItem])
             case .payment:
                 return createPaymentSection()
             }
         }
         return layout
+    }
+
+    private func createHeaderItem() -> NSCollectionLayoutBoundarySupplementaryItem {
+        let headerSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(Dimension.defaultWidth),
+            heightDimension: .estimated(Dimension.estimatedHeight)
+        )
+
+        let headerItem = NSCollectionLayoutBoundarySupplementaryItem(
+            layoutSize: headerSize,
+            elementKind: UICollectionView.elementKindSectionHeader,
+            alignment: .top
+        )
+
+        return headerItem
     }
 
     private func createMovieInfoSection() -> NSCollectionLayoutSection {
@@ -93,9 +116,9 @@ extension MovieCollectionView {
 
         let section = NSCollectionLayoutSection(group: group)
         section.contentInsets = .init(
-            top: .zero,
+            top: Inset.sectionTop,
             leading: Common.Config.defaultSpacing,
-            bottom: .zero,
+            bottom: Inset.sectionBottom,
             trailing: Common.Config.defaultSpacing
         )
         section.interGroupSpacing = Spacing.interGroup
@@ -104,7 +127,10 @@ extension MovieCollectionView {
         return section
     }
 
-    private func createCartSection() -> NSCollectionLayoutSection {
+    private func createCartSection(
+        supplementaryItems: [NSCollectionLayoutBoundarySupplementaryItem])
+        -> NSCollectionLayoutSection
+    {
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(Dimension.defaultWidth),
             heightDimension: .estimated(Dimension.estimatedHeight)
@@ -119,11 +145,12 @@ extension MovieCollectionView {
 
         let section = NSCollectionLayoutSection(group: group)
         section.contentInsets = .init(
-            top: Common.Config.verticalSpacing,
+            top: .zero,
             leading: Common.Config.defaultSpacing,
-            bottom: .zero,
+            bottom: Inset.sectionBottom,
             trailing: Common.Config.defaultSpacing
         )
+        section.boundarySupplementaryItems = supplementaryItems
 
         return section
     }
@@ -143,9 +170,9 @@ extension MovieCollectionView {
 
         let section = NSCollectionLayoutSection(group: group)
         section.contentInsets = .init(
-            top: Common.Config.verticalSpacing,
+            top: Inset.sectionTop,
             leading: Common.Config.defaultSpacing,
-            bottom: Common.Config.verticalSpacing,
+            bottom: Inset.sectionBottom,
             trailing: Common.Config.defaultSpacing
         )
 

--- a/Kiosk/Kiosk/Presentation/MainViewController+DataSource.swift
+++ b/Kiosk/Kiosk/Presentation/MainViewController+DataSource.swift
@@ -13,6 +13,7 @@ extension MainViewController {
     // DataSource 생성, 초기 스냅샷을 적용
     func configureDataSource() {
         dataSource = createDataSource()
+        createSupplementaryViewProvider()
         applyInitialSnapshot()
     }
 
@@ -69,6 +70,26 @@ extension MainViewController {
             ) as? PaymentCell
 
             return cell
+        }
+    }
+
+    private func createSupplementaryViewProvider() {
+        dataSource?.supplementaryViewProvider = { collectionView, kind, indexPath in
+            switch kind {
+            case UICollectionView.elementKindSectionHeader:
+                let headerView = collectionView.dequeueReusableSupplementaryView(
+                    ofKind: UICollectionView.elementKindSectionHeader,
+                    withReuseIdentifier: SectionHeaderView.reuseIdentifier,
+                    for: indexPath
+                ) as? SectionHeaderView
+
+                // TODO: title을 동적으로 업데이트하도록 수정
+                headerView?.update(title: "총 n장")
+
+                return headerView
+            default:
+                return nil
+            }
         }
     }
 

--- a/Kiosk/Kiosk/Presentation/MainViewController+DataSource.swift
+++ b/Kiosk/Kiosk/Presentation/MainViewController+DataSource.swift
@@ -87,6 +87,18 @@ extension MainViewController {
                 headerView?.update(title: "총 n장")
 
                 return headerView
+
+            case UICollectionView.elementKindSectionFooter:
+                let footerView = collectionView.dequeueReusableSupplementaryView(
+                    ofKind: UICollectionView.elementKindSectionFooter,
+                    withReuseIdentifier: PageControlFooterView.reuseIdentifier,
+                    for: indexPath
+                ) as? PageControlFooterView
+
+                footerView?.updateFooter()
+
+                return footerView
+
             default:
                 return nil
             }

--- a/Kiosk/Kiosk/Presentation/MovieInfo/MovieInfoConstant.swift
+++ b/Kiosk/Kiosk/Presentation/MovieInfo/MovieInfoConstant.swift
@@ -38,4 +38,9 @@ enum MovieInfoConstant {
         static let normalImage = "unselectedCircleButton"
         static let selectedImage = "selectedCircleButton"
     }
+
+    enum PageControlImageName {
+        static let defaultPage = "dot_small"
+        static let currentPage = "dot_large"
+    }
 }

--- a/Kiosk/Kiosk/Presentation/MovieInfo/Subview/PageControlFooterView.swift
+++ b/Kiosk/Kiosk/Presentation/MovieInfo/Subview/PageControlFooterView.swift
@@ -1,0 +1,59 @@
+//
+//  PageControlFooterView.swift
+//  Kiosk
+//
+//  Created by 곽다은 on 4/9/25.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class PageControlFooterView: UICollectionReusableView, ReuseIdentifying {
+    // MARK: - Components
+
+    let smallDot = UIImage(named: MovieInfoConstant.PageControlImageName.defaultPage)
+    let largeDot = UIImage(named: MovieInfoConstant.PageControlImageName.currentPage)
+
+    private let pageControl = UIPageControl().then {
+        $0.pageIndicatorTintColor = .kioskGray2
+        $0.currentPageIndicatorTintColor = .kioskRed
+        $0.currentPage = 0
+        $0.isUserInteractionEnabled = false
+    }
+
+    // MARK: - Init
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        configureUI()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+
+    // MARK: - Methods
+
+    private func configureUI() {
+        addSubview(pageControl)
+
+        pageControl.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(Common.Config.defaultSpacing)
+            $0.centerX.equalToSuperview()
+        }
+    }
+
+    func updateFooter() {
+        // TODO: 동적으로 업데이트
+        pageControl.numberOfPages = 5
+        pageControl.preferredIndicatorImage = smallDot
+
+        for number in 0 ..< 5 {
+            let image = (number == pageControl.currentPage) ? largeDot : smallDot
+            pageControl.setIndicatorImage(image, forPage: number)
+        }
+    }
+}

--- a/Kiosk/Kiosk/Resource/Assets.xcassets/dot_large.imageset/Contents.json
+++ b/Kiosk/Kiosk/Resource/Assets.xcassets/dot_large.imageset/Contents.json
@@ -1,0 +1,21 @@
+{
+  "images" : [
+    {
+      "filename" : "dot_large.svg",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Kiosk/Kiosk/Resource/Assets.xcassets/dot_large.imageset/dot_large.svg
+++ b/Kiosk/Kiosk/Resource/Assets.xcassets/dot_large.imageset/dot_large.svg
@@ -1,0 +1,3 @@
+<svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="15" cy="15" r="15" fill="#FF0000"/>
+</svg>

--- a/Kiosk/Kiosk/Resource/Assets.xcassets/dot_small.imageset/Contents.json
+++ b/Kiosk/Kiosk/Resource/Assets.xcassets/dot_small.imageset/Contents.json
@@ -1,0 +1,21 @@
+{
+  "images" : [
+    {
+      "filename" : "dot_small.svg",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Kiosk/Kiosk/Resource/Assets.xcassets/dot_small.imageset/dot_small.svg
+++ b/Kiosk/Kiosk/Resource/Assets.xcassets/dot_small.imageset/dot_small.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="10" cy="10" r="10" fill="#3D3B3B"/>
+</svg>


### PR DESCRIPTION
## 🔗 관련 작업  
- [📌 [Task] 컬렉션 보조뷰 추가](https://trello.com/c/2KeUWkqN/54-📌-task-컬렉션-보조뷰-추가)
- [📌 [Task] 페이지 컨트롤 푸터 구현](https://trello.com/c/p31d9PTl/44-📌-task-페이지-컨트롤-푸터-구현)  

## ✨ 변경 사항  
- 영화 정보 섹션에 사용되는 푸터 구현 및 레이아웃 정의: 페이지 컨트롤
- 장바구니 섹션에 사용되는 헤더 레이아웃 정의

## 🔍 변경 이유  
- 선택된 영화표의 총 갯수가 보여야합니다.
- 현재 페이지를 표시해야합니다.

## ✅ 체크리스트  
- [X] 코드가 정상적으로 동작하는지 확인했나요?  
- [ ] 관련된 테스트를 추가하거나 수정했나요?  
- [ ] 문서를 업데이트했나요? (필요한 경우)  
- [X] PR 제목이 적절한가요?  
- [X] 커밋 메시지가 명확한가요?  
- [X] 불필요한 파일이나 변경 사항이 포함되지 않았나요?  
- [X] 코드 스타일 및 포맷팅을 맞췄나요?  
- [X] 기존 기능을 깨뜨리지 않았나요?  
- [X] 리뷰어가 이해하기 쉽게 설명이 충분한가요?  

## 📸 변경 사항 (스크린샷 또는 동영상)  
https://github.com/user-attachments/assets/c7f344e9-ea13-4277-b4d8-ae6fccbb64b5

## 🚀 추가 정보  
없습니다.
