### PR TITLE
🧑‍💻 Fix: 전체삭제 / 결제 버튼 비활성화

### DIFF
--- a/Kiosk/Kiosk/Presentation/CollectionView/MovieSectionItem.swift
+++ b/Kiosk/Kiosk/Presentation/CollectionView/MovieSectionItem.swift
@@ -14,5 +14,5 @@ enum MovieSection: Hashable {
 enum MovieItem: Hashable {
     case movieInfo(Movie)
     case cart(Ticket)
-    case payment(Int)
+    case payment(totalPrice: Int, isEnable: Bool)
 }

--- a/Kiosk/Kiosk/Presentation/Payment/PaymentCell.swift
+++ b/Kiosk/Kiosk/Presentation/Payment/PaymentCell.swift
@@ -60,7 +60,12 @@ final class PaymentCell: UICollectionViewCell, ReuseIdentifying {
 
     func setButtonEnabled(_ isEnabled: Bool) {
         payButton.isEnabled = isEnabled ? true : false
+        payButton.backgroundColor = isEnabled ? .kioskBlue : .kioskGray3
+        payButton.setTitleColor(isEnabled ? .kioskWhite : .kioskGray2, for: .normal)
+
         deleteAllButton.isEnabled = isEnabled ? true : false
+        deleteAllButton.backgroundColor = isEnabled ? .kioskRed : .kioskGray3
+        deleteAllButton.setTitleColor(isEnabled ? .kioskWhite : .kioskGray2, for: .normal)
     }
 
     func setTotalPrice(_ totalPrice: Int) {

--- a/Kiosk/Kiosk/Presentation/Payment/PaymentCell.swift
+++ b/Kiosk/Kiosk/Presentation/Payment/PaymentCell.swift
@@ -27,7 +27,7 @@ final class PaymentCell: UICollectionViewCell, ReuseIdentifying {
         $0.spacing = PaymentConstant.Config.stackViewSpacing
     }
 
-    let deleteButton = UIButton().then {
+    let deleteAllButton = UIButton().then {
         $0.setTitle(PaymentConstant.Text.delete, for: .normal)
         $0.setTitleColor(.kioskWhite, for: .normal)
         $0.titleLabel?.font = Common.FontStyle.buttonTitle
@@ -58,12 +58,17 @@ final class PaymentCell: UICollectionViewCell, ReuseIdentifying {
 
     // MARK: - Methods
 
-    func configureTotalPrice(totalPrice: Int) {
+    func setButtonEnabled(_ isEnabled: Bool) {
+        payButton.isEnabled = isEnabled ? true : false
+        deleteAllButton.isEnabled = isEnabled ? true : false
+    }
+
+    func setTotalPrice(_ totalPrice: Int) {
         totalPriceLabel.text = PriceFormatHelper.format(totalPrice)
     }
 
     func showAlertAction() {
-        deleteButton.addAction(
+        deleteAllButton.addAction(
             makeAlertAction(
                 title: Payment.DeleteAlert.alertTitle,
                 message: Payment.DeleteAlert.alertMsg,
@@ -110,7 +115,7 @@ final class PaymentCell: UICollectionViewCell, ReuseIdentifying {
         [paymentLable, totalPriceLabel, hStackView]
             .forEach { addSubview($0) }
 
-        [deleteButton, payButton]
+        [deleteAllButton, payButton]
             .forEach { hStackView.addArrangedSubview($0) }
     }
 

--- a/Kiosk/Kiosk/Presentation/ViewController/MainViewController+DataSource.swift
+++ b/Kiosk/Kiosk/Presentation/ViewController/MainViewController+DataSource.swift
@@ -69,10 +69,11 @@ extension MainViewController {
                 for: indexPath
             ) as? PaymentCell
 
-            guard case let .payment(totalPrice) = item else { return nil }
+            guard case let .payment(totalPrice, isEnabled) = item else { return nil }
             cell?.delegate = self
             cell?.showAlertAction()
-            cell?.configureTotalPrice(totalPrice: totalPrice)
+            cell?.setTotalPrice(totalPrice)
+            cell?.setButtonEnabled(isEnabled)
             return cell
         }
     }
@@ -116,7 +117,7 @@ extension MainViewController {
         // TODO: 레이아웃 확인용, 데이터 연결 후 삭제
         initialSnapshot.appendItems(Movie.sampleData.map { MovieItem.movieInfo($0) }, toSection: .movieInfo)
         initialSnapshot.appendItems(mainViewModel.ticketList.map { MovieItem.cart($0) }, toSection: .cart)
-        initialSnapshot.appendItems([.payment(.zero)], toSection: .payment)
+        initialSnapshot.appendItems([.payment(totalPrice: .zero, isEnable: false)], toSection: .payment)
 
         sections = initialSnapshot.sectionIdentifiers
         collectionView.sections = sections

--- a/Kiosk/Kiosk/Presentation/ViewController/MainViewController.swift
+++ b/Kiosk/Kiosk/Presentation/ViewController/MainViewController.swift
@@ -77,10 +77,10 @@ class MainViewController: UIViewController {
 
     private func configureBinding() {
         mainViewModel.delegate = self
-        mainViewModel.onTotalPriceChanged = { [weak self] in
+        mainViewModel.onPaymentCellDataChanged = { [weak self] in
             guard let self, var snapshot = dataSource?.snapshot() else { return }
             snapshot.deleteItems(snapshot.itemIdentifiers(inSection: .payment))
-            snapshot.appendItems([.payment($0)], toSection: .payment)
+            snapshot.appendItems([.payment(totalPrice: $0, isEnable: $1)], toSection: .payment)
             dataSource?.apply(snapshot, animatingDifferences: true)
         }
     }

--- a/Kiosk/Kiosk/Presentation/ViewModel/MainViewModel.swift
+++ b/Kiosk/Kiosk/Presentation/ViewModel/MainViewModel.swift
@@ -8,17 +8,13 @@ final class MainViewModel {
     private let ticketPriceUseCase: TicketPriceUseCase
     private let ticketRegisterUseCase: TicketRegisterUseCase
 
-    var onTotalPriceChanged: ((Int) -> Void)?
+    var onPaymentCellDataChanged: ((Int, Bool) -> Void)?
 
     private(set) var ticketList: [Ticket] = [] {
         didSet {
-            updateTotalPrice()
-        }
-    }
-
-    private(set) var totalPrice: Int = 0 {
-        didSet {
-            onTotalPriceChanged?(totalPrice)
+            let totalPrice = updateTotalPrice()
+            let isEnabled = setButtonEnabled(basedOn: ticketList.count)
+            onPaymentCellDataChanged?(totalPrice, isEnabled)
         }
     }
 
@@ -41,6 +37,19 @@ final class MainViewModel {
 
     // MARK: - Methods
 
+    private func setButtonEnabled(basedOn listCount: Int) -> Bool {
+        return listCount == 0 ? false : true
+    }
+
+    private func updateTotalPrice() -> Int {
+        var totalPrice = 0
+        for ticket in ticketList {
+            let price = ticket.discountedPrice ?? ticket.originalPrice
+            totalPrice += price * ticket.count
+        }
+        return totalPrice
+    }
+
     func getMovie(at index: Int) -> Movie {
         movieList[index]
     }
@@ -56,15 +65,6 @@ final class MainViewModel {
         case .failure:
             delegate?.didAddDuplicatedTicket()
         }
-    }
-
-    func updateTotalPrice() {
-        var sum = 0
-        for ticket in ticketList {
-            let price = ticket.discountedPrice ?? ticket.originalPrice
-            sum += price * ticket.count
-        }
-        totalPrice = sum
     }
 
     func removeTicketList() {


### PR DESCRIPTION
## 🔗 관련 작업  
- [📌 [Task] 전체삭제 / 결제 버튼 비활성화](https://trello.com/c/KLjXSDTt/67-%F0%9F%93%8C-task-%EA%B2%B0%EC%A0%9C%EB%B2%84%ED%8A%BC-%EB%B9%84%ED%99%9C%EC%84%B1%ED%99%94)  

## ✨ 변경 사항  
- 요약: 장바구니가 비었을때 전체삭제 / 결제 버튼 비활성화
- 구체적 변경사항
     1. `CollectionView/MovieSectionItem` 에서 `MovieItem.payment(Int)` -> `MovieItem.payment(totalPrice: Int, isEnabled: Bool)`로 변경
     2. 비활성화 시, 버튼 색 회색으로 변경

## 🔍 변경 이유  
- 누락된 요구사항 수정

## ✅ 체크리스트  
- [x] 코드가 정상적으로 동작하는지 확인했나요?  
- [ ] 관련된 테스트를 추가하거나 수정했나요?  
- [ ] 문서를 업데이트했나요? (필요한 경우)  
- [x] PR 제목이 적절한가요?  
- [x] 커밋 메시지가 명확한가요?  
- [x] 불필요한 파일이나 변경 사항이 포함되지 않았나요?  
- [x] 코드 스타일 및 포맷팅을 맞췄나요?  
- [x] 기존 기능을 깨뜨리지 않았나요?  
- [x] 리뷰어가 이해하기 쉽게 설명이 충분한가요?  

## 📸 변경 사항 (스크린샷 또는 동영상)  
- 장바구니 항목이 있을 경우, 전체삭제 / 결제 버튼 활성화 됨
- 장바구니 항목이 비어있을 경우, 전체삭제 / 결제 버튼 비 활성화 됨

https://github.com/user-attachments/assets/49dfd1c7-5d58-4933-a8f4-0ec473a66727


## 🚀 추가 정보  
없어요
