### PR TITLE
✨ Feat: 티켓 추가 시 할인 옵션 적용

### DIFF
--- a/Kiosk/Kiosk/Presentation/CollectionView/MovieCollectionView.swift
+++ b/Kiosk/Kiosk/Presentation/CollectionView/MovieCollectionView.swift
@@ -19,6 +19,7 @@ final class MovieCollectionView: UIView {
 
     // MARK: - Properties
 
+    weak var delegate: MovieCollectionViewDelegate?
     var sections: [MovieSection]?
 
     // MARK: - Components
@@ -153,6 +154,10 @@ extension MovieCollectionView {
         section.interGroupSpacing = Spacing.interGroup
         section.orthogonalScrollingBehavior = .groupPagingCentered
         section.boundarySupplementaryItems = supplementaryItems
+        section.visibleItemsInvalidationHandler = { [weak self] _, offset, env in
+            let currentPage = Int(max(0, round(offset.x / env.container.contentSize.width)))
+            self?.delegate?.didChangeCurrentPage(currentPage)
+        }
 
         return section
     }

--- a/Kiosk/Kiosk/Presentation/CollectionView/MovieCollectionViewDelegate.swift
+++ b/Kiosk/Kiosk/Presentation/CollectionView/MovieCollectionViewDelegate.swift
@@ -1,0 +1,10 @@
+//
+//  MovieCollectionViewDelegate.swift
+//  Kiosk
+//
+//  Created by 곽다은 on 4/10/25.
+//
+
+protocol MovieCollectionViewDelegate: AnyObject {
+    func didChangeCurrentPage(_ page: Int)
+}

--- a/Kiosk/Kiosk/Presentation/MovieInfo/MovieInfoCell+RedCircleOptionButtonDelegate.swift
+++ b/Kiosk/Kiosk/Presentation/MovieInfo/MovieInfoCell+RedCircleOptionButtonDelegate.swift
@@ -11,8 +11,10 @@ extension MovieInfoCell: RedCircleOptionButtonDelegate {
         switch option {
         case .senior:
             delegate?.didTapSeniorButton()
+            updateSeniorButton()
         case .disabled:
             delegate?.didTapDisabledButton()
+            updateDisabledButton()
         }
     }
 }

--- a/Kiosk/Kiosk/Presentation/MovieInfo/MovieInfoCell+RedCircleOptionButtonDelegate.swift
+++ b/Kiosk/Kiosk/Presentation/MovieInfo/MovieInfoCell+RedCircleOptionButtonDelegate.swift
@@ -1,0 +1,18 @@
+//
+//  MovieInfoCell+RedCircleOptionButtonDelegate.swift
+//  Kiosk
+//
+//  Created by 곽다은 on 4/10/25.
+//
+
+extension MovieInfoCell: RedCircleOptionButtonDelegate {
+    func didTapButton(title: String) {
+        guard let option = BenefitOption(rawValue: title) else { return }
+        switch option {
+        case .senior:
+            delegate?.didTapSeniorButton()
+        case .disabled:
+            delegate?.didTapDisabledButton()
+        }
+    }
+}

--- a/Kiosk/Kiosk/Presentation/MovieInfo/MovieInfoCell.swift
+++ b/Kiosk/Kiosk/Presentation/MovieInfo/MovieInfoCell.swift
@@ -162,4 +162,16 @@ final class MovieInfoCell: UICollectionViewCell, ReuseIdentifying {
         actorView.setContent(movie.actor)
         synopsisLabel.text = movie.synopsis
     }
+
+    func updateSeniorButton() {
+        if !seniorBenefitButton.isSelected {
+            disabledBenefitButton.isSelected = false
+        }
+    }
+
+    func updateDisabledButton() {
+        if !disabledBenefitButton.isSelected {
+            seniorBenefitButton.isSelected = false
+        }
+    }
 }

--- a/Kiosk/Kiosk/Presentation/MovieInfo/MovieInfoCell.swift
+++ b/Kiosk/Kiosk/Presentation/MovieInfo/MovieInfoCell.swift
@@ -92,11 +92,11 @@ final class MovieInfoCell: UICollectionViewCell, ReuseIdentifying {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
+        setDelegate()
         setupUI()
         setupAddViews()
         setupConstraints()
         addActions()
-//        posterImageView.setContentHuggingPriority(.defaultHigh, for: .vertical)
     }
 
     @available(*, unavailable)
@@ -105,6 +105,11 @@ final class MovieInfoCell: UICollectionViewCell, ReuseIdentifying {
     }
 
     // MARK: - Methods
+
+    private func setDelegate() {
+        seniorBenefitButton.delegate = self
+        disabledBenefitButton.delegate = self
+    }
 
     private func setupUI() {
         layer.backgroundColor = UIColor.kioskGray3.cgColor

--- a/Kiosk/Kiosk/Presentation/MovieInfo/MovieInfoCell.swift
+++ b/Kiosk/Kiosk/Presentation/MovieInfo/MovieInfoCell.swift
@@ -174,4 +174,9 @@ final class MovieInfoCell: UICollectionViewCell, ReuseIdentifying {
             seniorBenefitButton.isSelected = false
         }
     }
+
+    func setSelectedOption(isSeniorSelected: Bool, isDisabledSelected: Bool) {
+        seniorBenefitButton.isSelected = isSeniorSelected
+        disabledBenefitButton.isSelected = isDisabledSelected
+    }
 }

--- a/Kiosk/Kiosk/Presentation/MovieInfo/MovieInfoCellDelegate.swift
+++ b/Kiosk/Kiosk/Presentation/MovieInfo/MovieInfoCellDelegate.swift
@@ -5,8 +5,8 @@
 //  Created by 곽다은 on 4/10/25.
 //
 
-import Foundation
-
 protocol MovieInfoCellDelegate: AnyObject {
     func didTapAddButton(in cell: MovieInfoCell)
+    func didTapSeniorButton()
+    func didTapDisabledButton()
 }

--- a/Kiosk/Kiosk/Presentation/MovieInfo/Subview/RedCircleOptionButton.swift
+++ b/Kiosk/Kiosk/Presentation/MovieInfo/Subview/RedCircleOptionButton.swift
@@ -13,6 +13,8 @@ import Then
 final class RedCircleOptionButton: UIButton {
     // MARK: - Properties
 
+    weak var delegate: RedCircleOptionButtonDelegate?
+
     private var optionTitle: String
 
     // MARK: - Init
@@ -41,8 +43,9 @@ final class RedCircleOptionButton: UIButton {
 
         addAction(UIAction(handler: { [weak self] _ in
             guard let self else { return }
-            self.isSelected.toggle()
-            self.setNeedsUpdateConfiguration()
+            delegate?.didTapButton(title: optionTitle)
+            isSelected.toggle()
+            setNeedsUpdateConfiguration()
         }), for: .touchUpInside)
     }
 

--- a/Kiosk/Kiosk/Presentation/MovieInfo/Subview/RedCircleOptionButtonDelegate.swift
+++ b/Kiosk/Kiosk/Presentation/MovieInfo/Subview/RedCircleOptionButtonDelegate.swift
@@ -1,0 +1,10 @@
+//
+//  RedCircleOptionButtonDelegate.swift
+//  Kiosk
+//
+//  Created by 곽다은 on 4/10/25.
+//
+
+protocol RedCircleOptionButtonDelegate: AnyObject {
+    func didTapButton(title: String)
+}

--- a/Kiosk/Kiosk/Presentation/ViewController/MainViewController+CartDelegate.swift
+++ b/Kiosk/Kiosk/Presentation/ViewController/MainViewController+CartDelegate.swift
@@ -3,6 +3,17 @@ import UIKit
 extension MainViewController: CartDelegate {
     private typealias Alert = CartConstant.Alert
 
+    func didChangeCurrentPage() {
+        guard let dataSource else { return }
+        var snapshot = dataSource.snapshot()
+
+        let items = snapshot.itemIdentifiers
+        snapshot.deleteItems(items)
+        snapshot.appendItems(items, toSection: .movieInfo)
+
+        dataSource.apply(snapshot, animatingDifferences: true)
+    }
+
     func didAddTicket(_ ticket: Ticket) {
         guard let dataSource else { return }
         var snapshot = dataSource.snapshot()

--- a/Kiosk/Kiosk/Presentation/ViewController/MainViewController+CartDelegate.swift
+++ b/Kiosk/Kiosk/Presentation/ViewController/MainViewController+CartDelegate.swift
@@ -4,14 +4,10 @@ extension MainViewController: CartDelegate {
     private typealias Alert = CartConstant.Alert
 
     func didChangeCurrentPage() {
-        guard let dataSource else { return }
-        var snapshot = dataSource.snapshot()
-
-        let items = snapshot.itemIdentifiers
-        snapshot.deleteItems(items)
-        snapshot.appendItems(items, toSection: .movieInfo)
-
-        dataSource.apply(snapshot, animatingDifferences: true)
+        for cell in collectionView.collectionView.visibleCells {
+            guard let cell = cell as? MovieInfoCell else { continue }
+            cell.setSelectedOption(isSeniorSelected: false, isDisabledSelected: false)
+        }
     }
 
     func didAddTicket(_ ticket: Ticket) {

--- a/Kiosk/Kiosk/Presentation/ViewController/MainViewController+MovieCollectionViewDelegate.swift
+++ b/Kiosk/Kiosk/Presentation/ViewController/MainViewController+MovieCollectionViewDelegate.swift
@@ -1,0 +1,12 @@
+//
+//  MainViewController+MovieCollectionViewDelegate.swift
+//  Kiosk
+//
+//  Created by 곽다은 on 4/10/25.
+//
+
+extension MainViewController: MovieCollectionViewDelegate {
+    func didChangeCurrentPage(_ page: Int) {
+        mainViewModel.changeCurrentPage(newPage: page)
+    }
+}

--- a/Kiosk/Kiosk/Presentation/ViewController/MainViewController+MovieInfoCellDelegate.swift
+++ b/Kiosk/Kiosk/Presentation/ViewController/MainViewController+MovieInfoCellDelegate.swift
@@ -16,8 +16,14 @@ extension MainViewController: MovieInfoCellDelegate {
         let movieIndex = indexPath.item
         let movie = mainViewModel.getMovie(at: movieIndex)
 
-        // TODO: viewModel의 옵션 상태 가져와서 option에 할당
-        mainViewModel.addTicket(of: movie, option: nil)
+        var option: BenefitOption?
+        if mainViewModel.isSeniorButtonSelected {
+            option = .senior
+        } else if mainViewModel.isDisabledButtonSelected {
+            option = .disabled
+        }
+
+        mainViewModel.addTicket(of: movie, option: option)
     }
 
     func didTapSeniorButton() {

--- a/Kiosk/Kiosk/Presentation/ViewController/MainViewController+MovieInfoCellDelegate.swift
+++ b/Kiosk/Kiosk/Presentation/ViewController/MainViewController+MovieInfoCellDelegate.swift
@@ -19,4 +19,12 @@ extension MainViewController: MovieInfoCellDelegate {
         // TODO: viewModel의 옵션 상태 가져와서 option에 할당
         mainViewModel.addTicket(of: movie, option: nil)
     }
+
+    func didTapSeniorButton() {
+        mainViewModel.toggleOptionButton(option: .senior)
+    }
+
+    func didTapDisabledButton() {
+        mainViewModel.toggleOptionButton(option: .disabled)
+    }
 }

--- a/Kiosk/Kiosk/Presentation/ViewController/MainViewController.swift
+++ b/Kiosk/Kiosk/Presentation/ViewController/MainViewController.swift
@@ -42,6 +42,8 @@ class MainViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        mainViewModel.delegate = self
+        collectionView.delegate = self
         configureSubview()
         configureAutoLayout()
         configureDataSource()

--- a/Kiosk/Kiosk/Presentation/ViewModel/CartDelegate.swift
+++ b/Kiosk/Kiosk/Presentation/ViewModel/CartDelegate.swift
@@ -1,4 +1,5 @@
 protocol CartDelegate: AnyObject {
+    func didChangeCurrentPage()
     func didAddTicket(_ ticket: Ticket)
     func didAddDuplicatedTicket()
     func didChangeTicket()

--- a/Kiosk/Kiosk/Presentation/ViewModel/MainViewModel.swift
+++ b/Kiosk/Kiosk/Presentation/ViewModel/MainViewModel.swift
@@ -25,6 +25,7 @@ final class MainViewModel {
         didSet {
             isSeniorButtonSelected = false
             isDisabledButtonSelected = false
+            delegate?.didChangeCurrentPage()
         }
     }
 

--- a/Kiosk/Kiosk/Presentation/ViewModel/MainViewModel.swift
+++ b/Kiosk/Kiosk/Presentation/ViewModel/MainViewModel.swift
@@ -21,7 +21,21 @@ final class MainViewModel {
 
     private(set) var movieList: [Movie] = []
 
-    private var ticket: Ticket?
+    private var isSeniorButtonSelected: Bool = false {
+        didSet {
+            if isDisabledButtonSelected, !oldValue {
+                isDisabledButtonSelected = false
+            }
+        }
+    }
+
+    private var isDisabledButtonSelected: Bool = false {
+        didSet {
+            if isSeniorButtonSelected, !oldValue {
+                isSeniorButtonSelected = false
+            }
+        }
+    }
 
     // MARK: - Init
 
@@ -66,6 +80,14 @@ final class MainViewModel {
             delegate?.didAddTicket(formattedTicket)
         case .failure:
             delegate?.didAddDuplicatedTicket()
+        }
+    }
+
+    func toggleOptionButton(option: BenefitOption) {
+        if option == .senior {
+            isSeniorButtonSelected.toggle()
+        } else {
+            isDisabledButtonSelected.toggle()
         }
     }
 

--- a/Kiosk/Kiosk/Presentation/ViewModel/MainViewModel.swift
+++ b/Kiosk/Kiosk/Presentation/ViewModel/MainViewModel.swift
@@ -29,7 +29,7 @@ final class MainViewModel {
         }
     }
 
-    private var isSeniorButtonSelected: Bool = false {
+    private(set) var isSeniorButtonSelected: Bool = false {
         didSet {
             if isDisabledButtonSelected, !oldValue {
                 isDisabledButtonSelected = false
@@ -37,7 +37,7 @@ final class MainViewModel {
         }
     }
 
-    private var isDisabledButtonSelected: Bool = false {
+    private(set) var isDisabledButtonSelected: Bool = false {
         didSet {
             if isSeniorButtonSelected, !oldValue {
                 isSeniorButtonSelected = false
@@ -84,8 +84,8 @@ final class MainViewModel {
         movieList[index]
     }
 
-    func addTicket(of movie: Movie, option _: BenefitOption?) {
-        let result = ticketRegisterUseCase.register(from: movie, option: nil, ticketList: ticketList)
+    func addTicket(of movie: Movie, option: BenefitOption?) {
+        let result = ticketRegisterUseCase.register(from: movie, option: option, ticketList: ticketList)
 
         switch result {
         case let .success(newTicket):

--- a/Kiosk/Kiosk/Presentation/ViewModel/MainViewModel.swift
+++ b/Kiosk/Kiosk/Presentation/ViewModel/MainViewModel.swift
@@ -89,6 +89,8 @@ final class MainViewModel {
         } else {
             isDisabledButtonSelected.toggle()
         }
+        print("isSenior: \(isSeniorButtonSelected)")
+        print("isDisabled: \(isDisabledButtonSelected)")
     }
 
     func removeTicketList() {

--- a/Kiosk/Kiosk/Presentation/ViewModel/MainViewModel.swift
+++ b/Kiosk/Kiosk/Presentation/ViewModel/MainViewModel.swift
@@ -21,6 +21,13 @@ final class MainViewModel {
 
     private(set) var movieList: [Movie] = []
 
+    private var currentMoviePage = 0 {
+        didSet {
+            isSeniorButtonSelected = false
+            isDisabledButtonSelected = false
+        }
+    }
+
     private var isSeniorButtonSelected: Bool = false {
         didSet {
             if isDisabledButtonSelected, !oldValue {
@@ -66,6 +73,12 @@ final class MainViewModel {
         return totalPrice
     }
 
+    func changeCurrentPage(newPage: Int) {
+        if newPage != currentMoviePage {
+            currentMoviePage = newPage
+        }
+    }
+
     func getMovie(at index: Int) -> Movie {
         movieList[index]
     }
@@ -89,8 +102,6 @@ final class MainViewModel {
         } else {
             isDisabledButtonSelected.toggle()
         }
-        print("isSenior: \(isSeniorButtonSelected)")
-        print("isDisabled: \(isDisabledButtonSelected)")
     }
 
     func removeTicketList() {


### PR DESCRIPTION
## 🔗 관련 작업  
- [📌 [Task] 할인 버튼 탭 이벤트 구현](https://trello.com/c/hWC5NLcn/57-📌-task-할인-버튼-탭-이벤트-구현)  

## ✨ 변경 사항  
- 할인 버튼이 배타적으로 선택되도록 구현 (모두 해제 시 일반 티켓)
- 할인 옵션 선택 후 다른 영화로 이동 시 할인 옵션을 초기화
- 티켓 추가 시 선택된 할인/우대 옵션에 따라서 할인 적용

## 🔍 변경 이유  
- (이 변경이 필요한 이유를 간단히 설명하세요)  

## ✅ 체크리스트  
- [X] 코드가 정상적으로 동작하는지 확인했나요?  
- [ ] 관련된 테스트를 추가하거나 수정했나요?  
- [ ] 문서를 업데이트했나요? (필요한 경우)  
- [X] PR 제목이 적절한가요?  
- [X] 커밋 메시지가 명확한가요?  
- [X] 불필요한 파일이나 변경 사항이 포함되지 않았나요?  
- [X] 코드 스타일 및 포맷팅을 맞췄나요?  
- [X] 기존 기능을 깨뜨리지 않았나요?  
- [X] 리뷰어가 이해하기 쉽게 설명이 충분한가요?  

## 📸 변경 사항 (스크린샷 또는 동영상)  
https://github.com/user-attachments/assets/bc27b0fd-b97f-4739-a15f-7ffbc81b21d1

## 🚀 추가 정보  
- 옵션 배타선택이 뷰모델을 통해서 하는게 아니라 뷰컨에서 수동으로 하도록 되어있습니다. (너무 야매지만 일단 돌아는 가니까 ㄱ-)
